### PR TITLE
A more reasonable log

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -272,11 +272,6 @@ class Cholesky
           return c;
       }
 
-      inline int iLog2(int val) {
-        int nbits=0;
-        while (val>>=1) nbits++;
-        return nbits;
-      }
       inline double SumDiff(const std::vector<double> &v1,const std::vector<double> &v2)
       {
          if (v1.size()!=v2.size()) return -1;

--- a/src/libsac/cost.h
+++ b/src/libsac/cost.h
@@ -130,7 +130,7 @@ class CostBitplane : public CostFunction {
   {
     int numsamples=buf.size();
     std::vector<int32_t> ubuf(numsamples);
-    int vmax=0;
+    int vmax=1;
     for (int i=0;i<numsamples;i++) {
        int val=MathUtils::S2U(buf[i]);
        if (val>vmax) vmax=val;
@@ -140,14 +140,14 @@ class CostBitplane : public CostFunction {
     BufIO iobuf;
     RangeCoderSH rc(iobuf);
     rc.Init();
-    BitplaneCoder bc_rc(MathUtils::iLog2(vmax),numsamples);
+    BitplaneCoder bc_rc(ilogb(vmax),numsamples);
     bc_rc.Encode(rc.encode_p1,&ubuf[0]);
     rc.Stop();
     double c0=iobuf.GetBufPos();
     #else
 
     StaticBitModel bm;
-    BitplaneCoder bc_bit(MathUtils::iLog2(vmax),numsamples);
+    BitplaneCoder bc_bit(ilogb(vmax),numsamples);
     bc_bit.Encode(bm.EncodeP1_Func(),&ubuf[0]);
 
     double c0=bm.nbits/8.0;

--- a/src/libsac/libsac.cpp
+++ b/src/libsac/libsac.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 #include <thread>
 #include <future>
 
@@ -225,7 +226,7 @@ int FrameCoder::EncodeMonoFrame_Mapped(int ch,int numsamples,BufIO &buf)
 double FrameCoder::CalcRemapError(int ch, int numsamples)
 {
     std::vector<int32_t>emap(numsamples);
-    int32_t emax_map=0;
+    int32_t emax_map=1;
     for (int i=0;i<numsamples;i++) {
       int32_t map_e=framestats[ch].mymap.Map(pred[ch][i],error[ch][i]);
       int32_t map_ue=MathUtils::S2U(map_e);
@@ -233,7 +234,7 @@ double FrameCoder::CalcRemapError(int ch, int numsamples)
       s2u_error_map[ch][i]=map_ue;
       if (map_ue>emax_map) emax_map=map_ue;
     }
-    framestats[ch].maxbpn_map=MathUtils::iLog2(emax_map);
+    framestats[ch].maxbpn_map=ilogb(emax_map);
 
     CostL1 cost;
 
@@ -418,13 +419,13 @@ void FrameCoder::CnvError_S2U(tch_samples &error,int numsamples)
 {
   for (int ch=0;ch<numchannels_;ch++)
   {
-    int32_t emax=0;
+    int32_t emax=1;
     for (int i=0;i<numsamples;i++) {
       const int32_t e_s2u=MathUtils::S2U(error[ch][i]);
       if (e_s2u>emax) emax=e_s2u;
       s2u_error[ch][i]=e_s2u;
     }
-    framestats[ch].maxbpn=MathUtils::iLog2(emax);
+    framestats[ch].maxbpn=ilogb(emax);
   }
 }
 

--- a/src/libsac/vle.cpp
+++ b/src/libsac/vle.cpp
@@ -51,15 +51,6 @@ void BitplaneCoder::GetSigState(int i)
   sigst[16]=i<numsamples-8?msb[i+8]:0;
 }
 
-static inline uint32_t ilog2(const uint32_t x) {
-  uint32_t y;
-  asm ( "\tbsr %1, %0\n"
-      : "=r"(y)
-      : "r" (x)
-  );
-  return y;
-}
-
 uint32_t BitplaneCoder::GetAvgSum(int n)
 {
   uint64_t nsum=0;


### PR DESCRIPTION
Replace O (n) and non cross platform implementation with ilogb() provided by<cmath>

Observing the original function, it was found that the minimum value at the call site is `0`, but the original function ilog2(0) == 0, while ilogb(0) != 0.

However, ilogb(1) == 0, and analysis shows that there is no difference whether the minimum value is 0 or 1.

Thus, the consistency between the original code and the pull code is verified.