### PR TITLE
Fix compilation errors with GCC

### DIFF
--- a/src/common/md5.h
+++ b/src/common/md5.h
@@ -2,6 +2,7 @@
 #define MD5_H
 
 #include <cstdint>
+#include <cstddef>
 
 namespace MD5 {
   typedef struct{


### PR DESCRIPTION
Otherwise it's `error: ‘size_t’ has not been declared`